### PR TITLE
Make git ignore installation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ packer_cache/
 
 # Ignore build outputs
 dockerfiles/build_output
+
+# Ignore currently used Nanocloud channel
+installation_dir/channel
+
+# Ignore IaaSAPI Windows image
+installation_dir/downloads/windows-custom-server-127.0.0.1-windows-server-std-2012R2-amd64.qcow2
+installation_dir/images/windows-custom-server-127.0.0.1-windows-server-std-2012R2-amd64.qcow2
+installation_dir/pid/windows-custom-server-127.0.0.1-windows-server-std-2012R2-amd64.pid


### PR DESCRIPTION
Some files (Windows qcow2 in install dire, pid file and channel's name) does not have to be versionned.